### PR TITLE
Modified regex to handle MSSQL Server URL as well

### DIFF
--- a/src/main/kotlin/com/github/yusufugurozbek/testcontainers/port/updater/DatasourceUrlExtractor.kt
+++ b/src/main/kotlin/com/github/yusufugurozbek/testcontainers/port/updater/DatasourceUrlExtractor.kt
@@ -2,7 +2,7 @@ package com.github.yusufugurozbek.testcontainers.port.updater
 
 class DatasourceUrlExtractor {
 
-    private val regex: Regex = "Database: (.*?)(?!\\S)".toRegex()
+    private val regex: Regex = "Database: ((.*?)((?!\\S)(\\s.*\\w.*;|)))".toRegex()
 
     internal fun extract(from: String): String? {
         val find = regex.find(from)

--- a/src/test/kotlin/com/github/yusufugurozbek/testcontainers/port/updater/DatasourceUrlExtractorTest.kt
+++ b/src/test/kotlin/com/github/yusufugurozbek/testcontainers/port/updater/DatasourceUrlExtractorTest.kt
@@ -2,8 +2,10 @@ package com.github.yusufugurozbek.testcontainers.port.updater
 
 import com.github.yusufugurozbek.testcontainers.port.updater.TestConstants.DATASOURCE_URL_1
 import com.github.yusufugurozbek.testcontainers.port.updater.TestConstants.DATASOURCE_URL_2
+import com.github.yusufugurozbek.testcontainers.port.updater.TestConstants.DATASOURCE_URL_MSSQL_SERVER
 import com.github.yusufugurozbek.testcontainers.port.updater.TestConstants.LOG_ENTRY_1
 import com.github.yusufugurozbek.testcontainers.port.updater.TestConstants.LOG_ENTRY_2
+import com.github.yusufugurozbek.testcontainers.port.updater.TestConstants.LOG_ENTRY_MSSQL_SERVER
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -24,5 +26,10 @@ internal class DatasourceUrlExtractorTest {
     @Test
     fun `extractDataSourceUrl returns null if not found`() {
         assertEquals(sut.extract("someGibberish"), null)
+    }
+
+    @Test
+    fun `extractDataSourceUrl successfully extracts mssql server url`() {
+        assertEquals(sut.extract(LOG_ENTRY_MSSQL_SERVER), DATASOURCE_URL_MSSQL_SERVER)
     }
 }

--- a/src/test/kotlin/com/github/yusufugurozbek/testcontainers/port/updater/TestConstants.kt
+++ b/src/test/kotlin/com/github/yusufugurozbek/testcontainers/port/updater/TestConstants.kt
@@ -3,10 +3,19 @@ package com.github.yusufugurozbek.testcontainers.port.updater
 object TestConstants {
     const val DATASOURCE_URL_1 = "jdbc:postgresql://localhost:55001/test"
     const val DATASOURCE_URL_2 = "jdbc:postgresql://localhost:55001/test?loggerLevel=OFF"
+    const val DATASOURCE_URL_MSSQL_SERVER = "jdbc:sqlserver://localhost:62510;connectRetryInterval=10;" +
+        "connectRetryCount=1;maxResultBuffer=-1;" +
+        "applicationName=Microsoft JDBC Driver for SQL Server;applicationIntent=readwrite;"
     const val LOG_ENTRY_1 = "2021-07-16 14:05:56.360  INFO [my-application,,] 33702 --- [" +
         "           main] o.f.c.i.database.base.DatabaseType       : " +
         "Database: jdbc:postgresql://localhost:55001/test (PostgreSQL 10.17)"
     const val LOG_ENTRY_2 = "2021-07-16 14:05:56.360  INFO [my-application,,] 33702 --- [" +
         "           main] o.f.c.i.database.base.DatabaseType       : " +
         "Database: jdbc:postgresql://localhost:55001/test?loggerLevel=OFF"
+    const val LOG_ENTRY_MSSQL_SERVER = "2022-09-24 17:33:36.058  INFO 26088 --- [" +
+        "           main] o.f.c.i.database.base.BaseDatabaseType   : " +
+        "Database: jdbc:sqlserver://localhost:62510;connectRetryInterval=10;" +
+        "connectRetryCount=1;maxResultBuffer=-1;" +
+        "applicationName=Microsoft JDBC Driver for SQL Server;" +
+        "applicationIntent=readwrite; (Microsoft SQL Server 14.0)"
 }


### PR DESCRIPTION
## Description

When using MSSQL Server as the selected database, the current regex doesn't retrieve the correct URL that the user has on the data source of IntelliJ IDEA.

Example:
User copied from logs the following and added it to the data source URL (some attributes were removed for clarity reasons because MSSQL Server has a lot of them):
```
jdbc:sqlserver://localhost:62510;connectRetryInterval=10;connectRetryCount=1;maxResultBuffer=-1;applicationName=Microsoft JDBC Driver for SQL Server;applicationIntent=readwrite;
```

In `DatasourceUpdaterImpl:update` the `newUrl` will have the following value from regex:
```
jdbc:sqlserver://localhost:62669;connectRetryInterval=10;connectRetryCount=1;maxResultBuffer=-1;applicationName=Microsoft
```

As you can see, from regex, the URL that is retrieved stops on `Microsoft` because it has space after that.
So this causes the comparison below to be false:
```kotlin
it.url?.equalsIgnoringPort(newUrl)
```

## Implementation
Modified regex to handle properly MSSQL Server URL as well.

The acceptable part of MSSQL Server after the `Microsoft` part continues with a space and ends with `;`.
`OR` operator was added with the first part of MSSQL Server and the second with the current implementation.
The order is **important** because if they are switched then we will still face the same original issue due to the MSSQL Server part that matches up until `Microsoft` part.

## Testing
In codebase a new test case was added for MSSQL Server.

Repository also created [here](https://github.com/ManolisPapd/demo_testcontainers_flyway) with three branches for respective databases:
- MSSQL Server
- PostgreSQL
- MySQL